### PR TITLE
Create new Lists for each page on List Tiles - Issue #3 Second Screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,9 @@ import 'package:to_dont_list/to_do_items.dart';
 import 'package:to_dont_list/to_do_nard.dart';
 
 class ToDoList extends StatefulWidget {
-  const ToDoList({super.key});
+  const ToDoList({super.key, required this.title});
+
+  final String title;
 
   @override
   State createState() => _ToDoListState();
@@ -175,6 +177,6 @@ class _ToDoListState extends State<ToDoList> {
 void main() {
   runApp(const MaterialApp(
     title: 'To Do List',
-    home: ToDoList(),
+    home: ToDoList(title: 'Home'),
   ));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:to_dont_list/to_do_items.dart';
 import 'package:to_dont_list/to_do_nard.dart';
 
-
 class ToDoList extends StatefulWidget {
   const ToDoList({super.key});
 
@@ -16,9 +15,9 @@ class _ToDoListState extends State<ToDoList> {
   final TextEditingController _inputController = TextEditingController();
   final TextEditingController _timeController = TextEditingController();
   final ButtonStyle yesStyle = ElevatedButton.styleFrom(
-      textStyle: const TextStyle(fontSize: 20), primary: Colors.green);
+      textStyle: const TextStyle(fontSize: 20), backgroundColor: Colors.green);
   final ButtonStyle noStyle = ElevatedButton.styleFrom(
-      textStyle: const TextStyle(fontSize: 20), primary: Colors.red);
+      textStyle: const TextStyle(fontSize: 20), backgroundColor: Colors.red);
 
   Future<void> _displayTextInputDialog(BuildContext context) async {
     print("Loading Dialog");
@@ -27,34 +26,32 @@ class _ToDoListState extends State<ToDoList> {
         builder: (context) {
           return AlertDialog(
             title: const Text('TO DO'),
-            content: Column(children: <Widget>[
-            TextField(
-                key: Key("ICKey"),
-                onChanged: (value) {
-                  setState(() {
-                    TaskText = value;
-                  });
-                },
-                controller: _inputController,
-                decoration:
-                    const InputDecoration(hintText: "type your task here"),
-                
-              ),
-              TextField(
-                key: Key("TCKey"),
-                onChanged: (value) {
-                  setState(() {
-                    TimeText = value;
-                  });
-                },
-                controller: _timeController,
-                decoration:
-                    const InputDecoration(hintText: "type the time here"),
-                
-              ),
+            content: Column(
+              children: <Widget>[
+                TextField(
+                  key: const Key("ICKey"),
+                  onChanged: (value) {
+                    setState(() {
+                      taskText = value;
+                    });
+                  },
+                  controller: _inputController,
+                  decoration:
+                      const InputDecoration(hintText: "type your task here"),
+                ),
+                TextField(
+                  key: const Key("TCKey"),
+                  onChanged: (value) {
+                    setState(() {
+                      timeText = value;
+                    });
+                  },
+                  controller: _timeController,
+                  decoration:
+                      const InputDecoration(hintText: "type the time here"),
+                ),
               ],
-              ),
-            
+            ),
             actions: <Widget>[
               ElevatedButton(
                 key: const Key("OkButton"),
@@ -62,7 +59,7 @@ class _ToDoListState extends State<ToDoList> {
                 child: const Text('OK'),
                 onPressed: () {
                   setState(() {
-                    _handleNewItem(TaskText,TimeText);
+                    _handleNewItem(taskText, timeText);
                     Navigator.pop(context);
                   });
                 },
@@ -79,8 +76,6 @@ class _ToDoListState extends State<ToDoList> {
                         ? () {
                             setState(() {
                               Navigator.pop(context);
-                              
-                
                             });
                           }
                         : null,
@@ -93,11 +88,11 @@ class _ToDoListState extends State<ToDoList> {
         });
   }
 
-  String TaskText = "";
-  String TimeText = "";
-  int task_counter = 0;
-  
- final List<Item> items = [Item("",time:"00:00", name: 'add to do')];
+  String taskText = "";
+  String timeText = "";
+  int taskCounter = 0;
+
+  final List<Item> items = [const Item("", time: "00:00", name: 'add to do')];
   final _itemSet = <Item>{};
 
   void _handleListChanged(Item item, bool completed) {
@@ -128,21 +123,22 @@ class _ToDoListState extends State<ToDoList> {
     });
   }
 
-  void _handleNewItem(String TaskText,String TimeText) {
+  void _handleNewItem(String TaskText, String TimeText) {
     setState(() {
       print("Adding new item");
-      Item item = Item("",name:TaskText,time: TimeText);
+      Item item = Item("", name: TaskText, time: timeText);
       items.insert(0, item);
       _inputController.clear();
       _timeController.clear();
     });
   }
+
   void _counter() {
     setState(() {
-      task_counter++;
+      taskCounter++;
     });
   }
-  
+
 //https://stackoverflow.com/questions/63515730/flutter-drawer-when-menu-icon-is-tapped
   @override
   Widget build(BuildContext context) {
@@ -152,7 +148,7 @@ class _ToDoListState extends State<ToDoList> {
         appBar: AppBar(
           title: const Text('Daily Planner'),
         ),
-         body: ListView(
+        body: ListView(
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           children: items.map((item) {
             return ToDoListItem(
@@ -164,22 +160,18 @@ class _ToDoListState extends State<ToDoList> {
           }).toList(),
         ),
         floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.add),
-            onPressed: () {
-              _displayTextInputDialog(context);
-            }
-            )
-      )
+          child: const Icon(Icons.add),
+          onPressed: () {
+            _displayTextInputDialog(context);
+          },
+        ),
+      ),
     );
   }
 }
 
+//return Scaffold(
 
-      
-    
-    //return Scaffold(
-        
-       
 void main() {
   runApp(const MaterialApp(
     title: 'To Do List',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,9 +146,9 @@ class _ToDoListState extends State<ToDoList> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        drawer: NewWindow(),
+        drawer: const NewWindow(),
         appBar: AppBar(
-          title: const Text('Daily Planner'),
+          title: Text(widget.title),
         ),
         body: ListView(
           padding: const EdgeInsets.symmetric(vertical: 8.0),

--- a/lib/to_do_items.dart
+++ b/lib/to_do_items.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 
 class Item {

--- a/lib/to_do_nard.dart
+++ b/lib/to_do_nard.dart
@@ -1,18 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:to_dont_list/to_do_items.dart';
+import 'package:to_dont_list/main.dart';
 
-class NewWindow extends StatefulWidget{
-  @override 
+// IMPROT NOT USED
+// import 'package:to_dont_list/to_do_items.dart';
+
+class NewWindow extends StatefulWidget {
+  const NewWindow({super.key});
+
+  @override
+  // ignore: library_private_types_in_public_api
   _NewWindowState createState() => _NewWindowState();
 }
-class _NewWindowState extends State <NewWindow>{
+
+class _NewWindowState extends State<NewWindow> {
   @override
   Widget build(BuildContext context) {
     return Theme(
-      data: Theme.of(context).copyWith(
-        canvasColor: Colors.blue[50],
-    ),
-    child: Drawer(
+        data: Theme.of(context).copyWith(
+          canvasColor: Colors.blue[50],
+        ),
+        child: Drawer(
           child: ListView(
             padding: EdgeInsets.zero,
             children: [
@@ -25,32 +32,38 @@ class _NewWindowState extends State <NewWindow>{
               ListTile(
                 title: const Text('All Tasks'),
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const ToDoList(
+                                title: 'All Tasks',
+                              )));
                 },
               ),
               ListTile(
                 title: const Text('Pending Tasks'),
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const ToDoList(
+                                title: 'Pending Tasks',
+                              )));
                 },
               ),
               ListTile(
                 title: const Text('Completed Tasks'),
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const ToDoList(
+                                title: 'Completed Tasks',
+                              )));
                 },
               ),
             ],
           ),
-        )
-      
-    );
-    
+        ));
   }
-
 }
-
-
-
-
-

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,12 +10,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:to_dont_list/main.dart';
 import 'package:to_dont_list/to_do_items.dart';
-import 'package:to_dont_list/to_do_nard.dart';
 
+// IMPORT NOT USED
+// import 'package:to_dont_list/to_do_nard.dart';
 
 void main() {
   test('Item abbreviation should be first letter', () {
-    const item = Item("",name: "add more todos", time: "");
+    const item = Item("", name: "add more todos", time: "");
     expect(item.abbrev(), "a");
   });
 
@@ -24,7 +25,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
         home: Scaffold(
             body: ToDoListItem(
-                item: const Item("",name: "test",time: ""),
+                item: const Item("", name: "test", time: ""),
                 completed: true,
                 onListChanged: (Item item, bool completed) {},
                 onDeleteItem: (Item item) {}))));
@@ -40,7 +41,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
         home: Scaffold(
             body: ToDoListItem(
-                item: const Item("",name: "test",time: ""),
+                item: const Item("", name: "test", time: ""),
                 completed: true,
                 onListChanged: (Item item, bool completed) {},
                 onDeleteItem: (Item item) {}))));
@@ -58,7 +59,8 @@ void main() {
   });
 
   testWidgets('Default ToDoList has one item', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: ToDoList()));
+    await tester
+        .pumpWidget(const MaterialApp(home: ToDoList(title: "Default Test")));
 
     final listItemFinder = find.byType(ToDoListItem);
 
@@ -66,7 +68,7 @@ void main() {
   });
 
   testWidgets('Clicking and Typing adds item to ToDoList', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: ToDoList()));
+    await tester.pumpWidget(const MaterialApp(home: ToDoList(title: 'Test')));
 
     expect(find.byType(TextField), findsNothing);
 
@@ -88,5 +90,4 @@ void main() {
   });
 
   // One to test the tap and press actions on the items?
-
 }


### PR DESCRIPTION
- Update ToDoList and build with title parameter
- Update Navigation within List Tiles when changing pages
- Add const keywords to remove warnings
- Remove unneeded imports

Note: This creates a new to do list for each list tile option when pressed (currently does not save the states of each of these lists when changing pages)